### PR TITLE
Run Android CI on "develop" branch

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,9 +2,9 @@ name: Android CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "develop", "master" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "develop", "master" ]
 
 jobs:
   build:


### PR DESCRIPTION
Proposing running the Android CI workflow on pushes to the `develop` branch too.